### PR TITLE
handle package.json without `dependencies` / `devDependencies`

### DIFF
--- a/api.js
+++ b/api.js
@@ -66,8 +66,8 @@ module.exports = {
             const appRoot = req.app.locals.appRoot;
             const packageJson = require(`${appRoot}/package.json`);
             const deps = [
-              ...Object.keys(packageJson.dependencies),
-              ...Object.keys(packageJson.devDependencies)
+              ...Object.keys(packageJson.dependencies || {}),
+              ...Object.keys(packageJson.devDependencies || {})
             ];
 
             installed = installed.filter(pkg =>


### PR DESCRIPTION
First of all, thank you for this awesome project!

A quick bug fix - currently, the code will fail if your `package.json` contains no `dependencies` section. I found this issue when I tried to use WebDash for [immer](https://github.com/mweststrate/immer). If you try to use this plugin with that project, you will get the following error:

```
C:\Projects\immer\node_modules\webdash-package-json\api.js:69
              ...Object.keys(packageJson.dependencies),
                        ^

TypeError: Cannot convert undefined or null to object
```
